### PR TITLE
Add support for non-string values in jsonToBundle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = '1.8.22'
-    ext.tealium_firebase_version = '1.6.0'
+    ext.tealium_firebase_version = '1.6.1'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = '1.8.22'
-    ext.tealium_firebase_version = '1.6.1'
+    ext.tealium_firebase_version = '1.7.0'
 
     repositories {
         google()

--- a/firebase/src/main/java/com/tealium/remotecommands/firebase/FirebaseInstance.java
+++ b/firebase/src/main/java/com/tealium/remotecommands/firebase/FirebaseInstance.java
@@ -180,7 +180,7 @@ class FirebaseInstance implements FirebaseCommand {
         if (value instanceof Long) {
             bundle.putLong(key, (Long) value);
         } else if (value instanceof Integer) {
-            bundle.putLong(key, (Integer) value);
+            bundle.putInt(key, (Integer) value);
         } else if (value instanceof Double) {
             bundle.putDouble(key, (Double) value);
         } else if (value instanceof Boolean) {

--- a/firebase/src/main/java/com/tealium/remotecommands/firebase/FirebaseInstance.java
+++ b/firebase/src/main/java/com/tealium/remotecommands/firebase/FirebaseInstance.java
@@ -166,7 +166,7 @@ class FirebaseInstance implements FirebaseCommand {
                         putPrimitive(bundle, firebaseKey, jsonObject.get(key));
                 }
             } catch (JSONException ex) {
-                Log.d(FirebaseConstants.TAG, "jsonToBundle: Error converting value for key: " + firebaseKey + ". Adding as using primitive fallback.");
+                Log.d(FirebaseConstants.TAG, "jsonToBundle: Error converting value for key: " + firebaseKey + ". Adding using primitive fallback.");
                 if (!bundle.containsKey(firebaseKey)) {
                     putPrimitive(bundle, firebaseKey, jsonObject.get(key));
                 }

--- a/firebase/src/main/java/com/tealium/remotecommands/firebase/FirebaseInstance.java
+++ b/firebase/src/main/java/com/tealium/remotecommands/firebase/FirebaseInstance.java
@@ -166,7 +166,7 @@ class FirebaseInstance implements FirebaseCommand {
                         putPrimitive(bundle, firebaseKey, jsonObject.get(key));
                 }
             } catch (JSONException ex) {
-                Log.d(FirebaseConstants.TAG, "jsonToBundle: Error converting value for key: " + firebaseKey + ". Adding as String.");
+                Log.d(FirebaseConstants.TAG, "jsonToBundle: Error converting value for key: " + firebaseKey + ". Adding as using primitive fallback.");
                 if (!bundle.containsKey(firebaseKey)) {
                     putPrimitive(bundle, firebaseKey, jsonObject.get(key));
                 }

--- a/firebase/src/main/java/com/tealium/remotecommands/firebase/FirebaseInstance.java
+++ b/firebase/src/main/java/com/tealium/remotecommands/firebase/FirebaseInstance.java
@@ -160,18 +160,29 @@ class FirebaseInstance implements FirebaseCommand {
                         }
                         bundle.putParcelableArray(firebaseKey, itemList);
                         break;
-                    // All others are Strings.
+                    // Unknown keys: preserve the parsed primitive type so that
+                    // large longs are not stringified to scientific notation.
                     default:
-                        bundle.putString(firebaseKey, jsonObject.getString(key));
+                        putPrimitive(bundle, firebaseKey, jsonObject.get(key));
                 }
             } catch (JSONException ex) {
                 Log.d(FirebaseConstants.TAG, "jsonToBundle: Error converting value for key: " + firebaseKey + ". Adding as String.");
                 if (!bundle.containsKey(firebaseKey)) {
-                    bundle.putString(firebaseKey, jsonObject.getString(key));
+                    putPrimitive(bundle, firebaseKey, jsonObject.get(key));
                 }
             }
         }
         return bundle;
+    }
+
+    static void putPrimitive(Bundle bundle, String key, Object value) {
+        if (value instanceof Long || value instanceof Integer) {
+            bundle.putLong(key, ((Number) value).longValue());
+        } else if (value instanceof Double || value instanceof Float) {
+            bundle.putDouble(key, ((Number) value).doubleValue());
+        } else {
+            bundle.putString(key, value.toString());
+        }
     }
 
     static String mapEventNames(String eventName) {

--- a/firebase/src/main/java/com/tealium/remotecommands/firebase/FirebaseInstance.java
+++ b/firebase/src/main/java/com/tealium/remotecommands/firebase/FirebaseInstance.java
@@ -176,10 +176,15 @@ class FirebaseInstance implements FirebaseCommand {
     }
 
     static void putPrimitive(Bundle bundle, String key, Object value) {
-        if (value instanceof Long || value instanceof Integer) {
-            bundle.putLong(key, ((Number) value).longValue());
-        } else if (value instanceof Double || value instanceof Float) {
-            bundle.putDouble(key, ((Number) value).doubleValue());
+        if (value == null || value == JSONObject.NULL) return;
+        if (value instanceof Long) {
+            bundle.putLong(key, (Long) value);
+        } else if (value instanceof Integer) {
+            bundle.putLong(key, (Integer) value);
+        } else if (value instanceof Double) {
+            bundle.putDouble(key, (Double) value);
+        } else if (value instanceof Boolean) {
+            bundle.putBoolean(key, (Boolean) value);
         } else {
             bundle.putString(key, value.toString());
         }

--- a/firebase/src/test/java/com/tealium/remotecommands/firebase/FirebaseInstanceTests.java
+++ b/firebase/src/test/java/com/tealium/remotecommands/firebase/FirebaseInstanceTests.java
@@ -315,7 +315,7 @@ public class FirebaseInstanceTests {
     }
 
     @Test
-    public void logEvent_Stringifies_Boolean_On_UnknownKey() throws JSONException {
+    public void logEvent_Preserves_Boolean_On_UnknownKey() throws JSONException {
         JSONObject params = new JSONObject();
         params.put("my_custom_bool", true);
 
@@ -325,6 +325,6 @@ public class FirebaseInstanceTests {
         verify(mockFirebaseAnalytics).logEvent(eq("TestEvent"), bundleCaptor.capture());
 
         Bundle bundle = bundleCaptor.getValue();
-        assertEquals("true", bundle.getString("my_custom_bool"));
+        assertEquals(true, bundle.getBoolean("my_custom_bool"));
     }
 }

--- a/firebase/src/test/java/com/tealium/remotecommands/firebase/FirebaseInstanceTests.java
+++ b/firebase/src/test/java/com/tealium/remotecommands/firebase/FirebaseInstanceTests.java
@@ -256,4 +256,75 @@ public class FirebaseInstanceTests {
     public void mapParams_ReturnsValue_When_NotMatched() {
         assertEquals("my_custom_param", FirebaseInstance.mapParams("my_custom_param"));
     }
+
+    @Test
+    public void logEvent_Preserves_LargeLong_On_UnknownKey() throws JSONException {
+        long largeValue = 10_000_000_000L;
+        JSONObject params = new JSONObject();
+        params.put("my_custom_long", largeValue);
+
+        firebaseInstance.logEvent("TestEvent", params);
+
+        ArgumentCaptor<Bundle> bundleCaptor = ArgumentCaptor.forClass(Bundle.class);
+        verify(mockFirebaseAnalytics).logEvent(eq("TestEvent"), bundleCaptor.capture());
+
+        Bundle bundle = bundleCaptor.getValue();
+        assertEquals(largeValue, bundle.getLong("my_custom_long"));
+    }
+
+    @Test
+    public void logEvent_Preserves_Int_As_Long_On_UnknownKey() throws JSONException {
+        JSONObject params = new JSONObject();
+        params.put("my_custom_int", 42);
+
+        firebaseInstance.logEvent("TestEvent", params);
+
+        ArgumentCaptor<Bundle> bundleCaptor = ArgumentCaptor.forClass(Bundle.class);
+        verify(mockFirebaseAnalytics).logEvent(eq("TestEvent"), bundleCaptor.capture());
+
+        Bundle bundle = bundleCaptor.getValue();
+        assertEquals(42L, bundle.getLong("my_custom_int"));
+    }
+
+    @Test
+    public void logEvent_Preserves_Double_On_UnknownKey() throws JSONException {
+        JSONObject params = new JSONObject();
+        params.put("my_custom_double", 9.99);
+
+        firebaseInstance.logEvent("TestEvent", params);
+
+        ArgumentCaptor<Bundle> bundleCaptor = ArgumentCaptor.forClass(Bundle.class);
+        verify(mockFirebaseAnalytics).logEvent(eq("TestEvent"), bundleCaptor.capture());
+
+        Bundle bundle = bundleCaptor.getValue();
+        assertEquals(9.99, bundle.getDouble("my_custom_double"), 0.0001);
+    }
+
+    @Test
+    public void logEvent_Preserves_String_On_UnknownKey() throws JSONException {
+        JSONObject params = new JSONObject();
+        params.put("my_custom_string", "hello");
+
+        firebaseInstance.logEvent("TestEvent", params);
+
+        ArgumentCaptor<Bundle> bundleCaptor = ArgumentCaptor.forClass(Bundle.class);
+        verify(mockFirebaseAnalytics).logEvent(eq("TestEvent"), bundleCaptor.capture());
+
+        Bundle bundle = bundleCaptor.getValue();
+        assertEquals("hello", bundle.getString("my_custom_string"));
+    }
+
+    @Test
+    public void logEvent_Stringifies_Boolean_On_UnknownKey() throws JSONException {
+        JSONObject params = new JSONObject();
+        params.put("my_custom_bool", true);
+
+        firebaseInstance.logEvent("TestEvent", params);
+
+        ArgumentCaptor<Bundle> bundleCaptor = ArgumentCaptor.forClass(Bundle.class);
+        verify(mockFirebaseAnalytics).logEvent(eq("TestEvent"), bundleCaptor.capture());
+
+        Bundle bundle = bundleCaptor.getValue();
+        assertEquals("true", bundle.getString("my_custom_bool"));
+    }
 }


### PR DESCRIPTION
- Large integers passed as event params were being converted to scientific notation strings (e.g. 10000000000 → "1.0E10") because unknown params fell through to getString()
- Added a `putPrimitive` helper to preserve the parsed type when adding unknown params to the Bundle   