### PR TITLE
[MT-2019] - Additional primitive support for unknown keys

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
+    kotlin {
+        jvmToolchain(17)
+    }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -29,10 +33,10 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation "com.tealium:kotlin-core:1.6.0"
-    implementation "com.tealium:kotlin-remotecommand-dispatcher:1.4.0"
-    implementation "com.tealium:kotlin-tagmanagement-dispatcher:1.2.3"
-    implementation "com.tealium:kotlin-lifecycle:1.2.0"
+    implementation "com.tealium:kotlin-core:1.9.2"
+    implementation "com.tealium:kotlin-remotecommand-dispatcher:1.5.3"
+    implementation "com.tealium:kotlin-tagmanagement-dispatcher:1.3.1"
+    implementation "com.tealium:kotlin-lifecycle:1.2.3"
     releaseImplementation "com.tealium.remotecommands:firebase:$tealium_firebase_version"
     debugImplementation project(path:':firebase')
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.kotlin_version = '1.8.22'
-    ext.tealium_firebase_version = '1.7.0'
+    ext.tealium_firebase_version = '1.7.1'
 
     repositories {
         google()

--- a/firebase/build.gradle
+++ b/firebase/build.gradle
@@ -25,6 +25,11 @@ android {
     publishing {
         singleVariant("release")
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 afterEvaluate {

--- a/firebase/src/main/java/com/tealium/remotecommands/firebase/FirebaseInstance.java
+++ b/firebase/src/main/java/com/tealium/remotecommands/firebase/FirebaseInstance.java
@@ -183,6 +183,14 @@ class FirebaseInstance implements FirebaseCommand {
             bundle.putInt(key, (Integer) value);
         } else if (value instanceof Double) {
             bundle.putDouble(key, (Double) value);
+        } else if (value instanceof Float) {
+            bundle.putFloat(key, (Float) value);
+        } else if (value instanceof Short) {
+            bundle.putShort(key, (Short) value);
+        } else if (value instanceof Byte) {
+            bundle.putByte(key, (Byte) value);
+        } else if (value instanceof Character) {
+            bundle.putChar(key, (Character) value);
         } else if (value instanceof Boolean) {
             bundle.putBoolean(key, (Boolean) value);
         } else {

--- a/firebase/src/test/java/com/tealium/remotecommands/firebase/FirebaseInstanceTests.java
+++ b/firebase/src/test/java/com/tealium/remotecommands/firebase/FirebaseInstanceTests.java
@@ -273,7 +273,7 @@ public class FirebaseInstanceTests {
     }
 
     @Test
-    public void logEvent_Preserves_Int_As_Long_On_UnknownKey() throws JSONException {
+    public void logEvent_Preserves_Int_On_UnknownKey() throws JSONException {
         JSONObject params = new JSONObject();
         params.put("my_custom_int", 42);
 

--- a/firebase/src/test/java/com/tealium/remotecommands/firebase/FirebaseInstanceTests.java
+++ b/firebase/src/test/java/com/tealium/remotecommands/firebase/FirebaseInstanceTests.java
@@ -283,7 +283,7 @@ public class FirebaseInstanceTests {
         verify(mockFirebaseAnalytics).logEvent(eq("TestEvent"), bundleCaptor.capture());
 
         Bundle bundle = bundleCaptor.getValue();
-        assertEquals(42L, bundle.getLong("my_custom_int"));
+        assertEquals(42, bundle.getInt("my_custom_int"));
     }
 
     @Test
@@ -298,6 +298,70 @@ public class FirebaseInstanceTests {
 
         Bundle bundle = bundleCaptor.getValue();
         assertEquals(9.99, bundle.getDouble("my_custom_double"), 0.0001);
+    }
+
+    @Test
+    public void logEvent_Preserves_Float_On_UnknownKey() throws JSONException {
+        // JSONObject converts Float to Double when putting or parsing from string.
+        // But will accept it when constructed from a map.
+        Map<String, Float> map = Map.of("my_custom_float", 9.99f);
+        JSONObject params = new JSONObject(map);
+
+        firebaseInstance.logEvent("TestEvent", params);
+
+        ArgumentCaptor<Bundle> bundleCaptor = ArgumentCaptor.forClass(Bundle.class);
+        verify(mockFirebaseAnalytics).logEvent(eq("TestEvent"), bundleCaptor.capture());
+
+        Bundle bundle = bundleCaptor.getValue();
+        assertEquals(9.99f, bundle.getFloat("my_custom_float"), 0.0001);
+    }
+
+    @Test
+    public void logEvent_Preserves_Short_On_UnknownKey() throws JSONException {
+        // JSONObject converts Short to Int when putting or parsing from string.
+        // But will accept it when constructed from a map.
+        Map<String, Short> map = Map.of("my_custom_short", (short) 9);
+        JSONObject params = new JSONObject(map);
+
+        firebaseInstance.logEvent("TestEvent", params);
+
+        ArgumentCaptor<Bundle> bundleCaptor = ArgumentCaptor.forClass(Bundle.class);
+        verify(mockFirebaseAnalytics).logEvent(eq("TestEvent"), bundleCaptor.capture());
+
+        Bundle bundle = bundleCaptor.getValue();
+        assertEquals((short) 9, bundle.getShort("my_custom_short"));
+    }
+
+    @Test
+    public void logEvent_Preserves_Byte_On_UnknownKey() throws JSONException {
+        // JSONObject converts Byte to Int when putting or parsing from string.
+        // But will accept it when constructed from a map.
+        Map<String, Byte> map = Map.of("my_custom_byte", (byte) 2);
+        JSONObject params = new JSONObject(map);
+
+        firebaseInstance.logEvent("TestEvent", params);
+
+        ArgumentCaptor<Bundle> bundleCaptor = ArgumentCaptor.forClass(Bundle.class);
+        verify(mockFirebaseAnalytics).logEvent(eq("TestEvent"), bundleCaptor.capture());
+
+        Bundle bundle = bundleCaptor.getValue();
+        assertEquals(2, bundle.getByte("my_custom_byte"));
+    }
+
+    @Test
+    public void logEvent_Preserves_Character_On_UnknownKey() throws JSONException {
+        // JSONObject converts Character to String when putting or parsing from string.
+        // But will accept it when constructed from a map.
+        Map<String, Character> map = Map.of("my_custom_char", 'a');
+        JSONObject params = new JSONObject(map);
+
+        firebaseInstance.logEvent("TestEvent", params);
+
+        ArgumentCaptor<Bundle> bundleCaptor = ArgumentCaptor.forClass(Bundle.class);
+        verify(mockFirebaseAnalytics).logEvent(eq("TestEvent"), bundleCaptor.capture());
+
+        Bundle bundle = bundleCaptor.getValue();
+        assertEquals('a', bundle.getChar("my_custom_char"));
     }
 
     @Test

--- a/firebase/src/test/java/com/tealium/remotecommands/firebase/FirebaseInstanceTests.java
+++ b/firebase/src/test/java/com/tealium/remotecommands/firebase/FirebaseInstanceTests.java
@@ -313,7 +313,7 @@ public class FirebaseInstanceTests {
         verify(mockFirebaseAnalytics).logEvent(eq("TestEvent"), bundleCaptor.capture());
 
         Bundle bundle = bundleCaptor.getValue();
-        assertEquals(9.99f, bundle.getFloat("my_custom_float"), 0.0001);
+        assertEquals(9.99f, bundle.getFloat("my_custom_float"), 0.0001f);
     }
 
     @Test
@@ -345,7 +345,7 @@ public class FirebaseInstanceTests {
         verify(mockFirebaseAnalytics).logEvent(eq("TestEvent"), bundleCaptor.capture());
 
         Bundle bundle = bundleCaptor.getValue();
-        assertEquals(2, bundle.getByte("my_custom_byte"));
+        assertEquals((byte) 2, bundle.getByte("my_custom_byte"));
     }
 
     @Test


### PR DESCRIPTION
Why
 - JSONObject allows additional primitives when constructing from a Map.
 - Current `putPrimitive` method only handles the primitives that would be present when constructing using parsing, or `put`ting - `String`, `Int`, `Long`, `Double` and `Boolean`

What
 - Additional primitive type checks for `Float`, `Short`, `Byte` and `Character` just in case to ensure `Bundle` receives the appropriate type.